### PR TITLE
.1502411993651747:5dcd3d2aaeb915f3581a6ae395fe883f_69f1bb4d666bfaca1f19827b.69f1bb69666bfaca1f19828a.69f1bb690d92d3a5b23bf477:Trae CN.T(2026/4/29 16:03:53)

### DIFF
--- a/api/main.ts
+++ b/api/main.ts
@@ -1,7 +1,26 @@
 import { Application, Router } from "@oak/oak";
 import { oakCors } from "@tajpouria/cors";
-import routeStaticFilesFrom from "./util/routeStaticFilesFrom.ts";
+import routeStaticFilesFrom "./util/routeStaticFilesFrom.ts";
 import data from "./data.json" with { type: "json" };
+
+const kv = await Deno.openKv();
+const FAVORITES_KEY = ["favorites"];
+
+async function getFavorites(): Promise<string[]> {
+    const entry = await kv.get<string[]>(FAVORITES_KEY);
+    return entry.value ?? [];
+}
+
+async function setFavorites(favorites: string[]): Promise<void> {
+    await kv.set(FAVORITES_KEY, favorites);
+}
+
+async function isFavorite(dinosaurName: string): Promise<boolean> {
+    const favorites = await getFavorites();
+    return favorites.some(fav => 
+        fav.toLowerCase() === dinosaurName.toLowerCase()
+    );
+}
 
 export const app = new Application();
 const router = new Router();
@@ -20,6 +39,58 @@ router.get("/api/dinosaurs/:dinosaur", (context) => {
     );
 
     context.response.body = dinosaur ?? "No dinosaur found.";
+});
+
+router.get("/api/favorites", async (context) => {
+    const favorites = await getFavorites();
+    const favoriteDinosaurs = data.filter(dino => 
+        favorites.some(fav => fav.toLowerCase() === dino.name.toLowerCase())
+    );
+    context.response.body = favoriteDinosaurs;
+});
+
+router.get("/api/favorites/:dinosaur", async (context) => {
+    const dinosaurName = context.params.dinosaur;
+    const favorite = await isFavorite(dinosaurName);
+    context.response.body = { isFavorite: favorite };
+});
+
+router.post("/api/favorites/:dinosaur", async (context) => {
+    const dinosaurName = context.params.dinosaur;
+    const dinosaur = data.find((item) =>
+        item.name.toLowerCase() === dinosaurName.toLowerCase()
+    );
+
+    if (!dinosaur) {
+        context.response.status = 404;
+        context.response.body = { error: "Dinosaur not found" };
+        return;
+    }
+
+    const favorites = await getFavorites();
+    const alreadyFavorite = favorites.some(fav => 
+        fav.toLowerCase() === dinosaurName.toLowerCase()
+    );
+
+    if (!alreadyFavorite) {
+        favorites.push(dinosaur.name);
+        await setFavorites(favorites);
+    }
+
+    context.response.body = { isFavorite: true, dinosaur: dinosaur.name };
+});
+
+router.delete("/api/favorites/:dinosaur", async (context) => {
+    const dinosaurName = context.params.dinosaur;
+    const favorites = await getFavorites();
+    
+    const newFavorites = favorites.filter(fav => 
+        fav.toLowerCase() !== dinosaurName.toLowerCase()
+    );
+    
+    await setFavorites(newFavorites);
+    
+    context.response.body = { isFavorite: false, dinosaur: dinosaurName };
 });
 
 app.use(oakCors());

--- a/src/components/Dinosaur.vue
+++ b/src/components/Dinosaur.vue
@@ -5,12 +5,60 @@ export default defineComponent({
     props: { dinosaur: String },
     data(): ComponentData {
         return {
-            dinosaurDetails: null
+            dinosaurDetails: null,
+            isFavorite: false,
+            isLoading: false
         };
     },
     async mounted() {
         const res = await fetch(`/api/dinosaurs/${this.dinosaur}`);
         this.dinosaurDetails = await res.json();
+        
+        await this.checkFavoriteStatus();
+    },
+    watch: {
+        dinosaur: {
+            immediate: false,
+            async handler(newDino) {
+                if (newDino) {
+                    const res = await fetch(`/api/dinosaurs/${newDino}`);
+                    this.dinosaurDetails = await res.json();
+                    await this.checkFavoriteStatus();
+                }
+            }
+        }
+    },
+    methods: {
+        async checkFavoriteStatus() {
+            if (!this.dinosaur) return;
+            try {
+                const res = await fetch(`/api/favorites/${this.dinosaur}`);
+                const data = await res.json();
+                this.isFavorite = data.isFavorite;
+            } catch (error) {
+                console.error('Failed to check favorite status:', error);
+            }
+        },
+        async toggleFavorite() {
+            if (!this.dinosaurDetails || this.isLoading) return;
+            
+            this.isLoading = true;
+            try {
+                const dinosaurName = this.dinosaurDetails.name;
+                const method = this.isFavorite ? 'DELETE' : 'POST';
+                
+                const res = await fetch(`/api/favorites/${encodeURIComponent(dinosaurName)}`, {
+                    method: method
+                });
+                
+                const data = await res.json();
+                this.isFavorite = data.isFavorite;
+            } catch (error) {
+                console.error('Failed to toggle favorite:', error);
+            } finally {
+                this.isLoading = false;
+            }
+        }
     }
 });
 </script>
@@ -18,5 +66,25 @@ export default defineComponent({
 <template>
     <h1>{{ dinosaurDetails?.name }}</h1>
     <p>{{ dinosaurDetails?.description }}</p>
+    
+    <div style="margin: 20px 0;">
+        <button 
+            @click="toggleFavorite" 
+            :disabled="isLoading"
+            :style="{
+                padding: '10px 20px',
+                fontSize: '16px',
+                cursor: isLoading ? 'not-allowed' : 'pointer',
+                backgroundColor: isFavorite ? '#ff4757' : '#fff',
+                color: isFavorite ? '#fff' : '#ff4757',
+                border: '2px solid #ff4757',
+                borderRadius: '5px',
+                fontWeight: 'bold'
+            }"
+        >
+            {{ isLoading ? 'Processing...' : (isFavorite ? '❤️ 已收藏' : '🤍 添加收藏') }}
+        </button>
+    </div>
+    
     <RouterLink to="/" class="btn btn-secondary">Back to all dinosaurs</RouterLink>
 </template>

--- a/src/components/Dinosaurs.vue
+++ b/src/components/Dinosaurs.vue
@@ -1,20 +1,138 @@
 <script lang="ts">
-import { defineComponent } from 'vue';
+import { defineComponent, ref, computed, onMounted } from 'vue';
 
 export default defineComponent({
-    async setup() {
-        const res = await fetch("/api/dinosaurs")
-        const dinosaurs = await res.json() as Dinosaur[];
-        return { dinosaurs };
+    setup() {
+        const allDinosaurs = ref<Dinosaur[]>([]);
+        const favoriteDinosaurs = ref<Dinosaur[]>([]);
+        const showFavoritesOnly = ref(false);
+        const isLoading = ref(true);
+        const isRefreshing = ref(false);
+
+        const displayedDinosaurs = computed(() => {
+            return showFavoritesOnly.value ? favoriteDinosaurs.value : allDinosaurs.value;
+        });
+
+        const favoriteCount = computed(() => favoriteDinosaurs.value.length);
+
+        async function loadData(showLoadingState: boolean = true) {
+            if (showLoadingState) {
+                isLoading.value = true;
+            }
+            isRefreshing.value = true;
+            
+            try {
+                const [allRes, favRes] = await Promise.all([
+                    fetch("/api/dinosaurs"),
+                    fetch("/api/favorites")
+                ]);
+                
+                allDinosaurs.value = await allRes.json() as Dinosaur[];
+                favoriteDinosaurs.value = await favRes.json() as Dinosaur[];
+            } catch (error) {
+                console.error('Failed to load data:', error);
+            } finally {
+                isLoading.value = false;
+                isRefreshing.value = false;
+            }
+        }
+
+        function toggleFavoritesOnly() {
+            showFavoritesOnly.value = !showFavoritesOnly.value;
+        }
+
+        function isFavorite(dinosaur: Dinosaur): boolean {
+            return favoriteDinosaurs.value.some(fav => 
+                fav.name.toLowerCase() === dinosaur.name.toLowerCase()
+            );
+        }
+
+        onMounted(() => {
+            loadData();
+        });
+
+        return {
+            allDinosaurs,
+            favoriteDinosaurs,
+            showFavoritesOnly,
+            displayedDinosaurs,
+            favoriteCount,
+            isLoading,
+            isRefreshing,
+            toggleFavoritesOnly,
+            isFavorite,
+            loadData
+        };
     }
 });
 </script>
 
 <template>
-    <span v-for="dinosaur in dinosaurs" :key="dinosaur.name">
-        <RouterLink :to="{ name: 'Dinosaur', params: { dinosaur: `${dinosaur.name.toLowerCase()}` } }"
-            class="btn btn-primary">
-            {{ dinosaur.name }}
-        </RouterLink>
-    </span>
+    <div v-if="isLoading && !isRefreshing">
+        <p>Loading dinosaurs...</p>
+    </div>
+    
+    <div v-else>
+        <div style="margin-bottom: 20px; display: flex; gap: 10px; align-items: center; flex-wrap: wrap;">
+            <button 
+                @click="toggleFavoritesOnly"
+                :style="{
+                    padding: '10px 20px',
+                    fontSize: '14px',
+                    cursor: 'pointer',
+                    backgroundColor: showFavoritesOnly ? '#ff4757' : '#f1f1f1',
+                    color: showFavoritesOnly ? '#fff' : '#333',
+                    border: '2px solid #ff4757',
+                    borderRadius: '5px',
+                    fontWeight: 'bold'
+                }"
+            >
+                {{ showFavoritesOnly ? '❤️ 显示全部' : '🤍 只看收藏' }}
+                <span v-if="favoriteCount > 0" style="margin-left: 8px;">
+                    ({{ favoriteCount }})
+                </span>
+            </button>
+            
+            <button 
+                @click="loadData(false)"
+                :disabled="isRefreshing"
+                :style="{
+                    padding: '10px 15px',
+                    fontSize: '14px',
+                    cursor: isRefreshing ? 'not-allowed' : 'pointer',
+                    backgroundColor: '#4CAF50',
+                    color: '#fff',
+                    border: '2px solid #4CAF50',
+                    borderRadius: '5px',
+                    fontWeight: 'bold'
+                }"
+            >
+                {{ isRefreshing ? '🔄 刷新中...' : '🔄 刷新' }}
+            </button>
+        </div>
+        
+        <div v-if="showFavoritesOnly && favoriteCount === 0" 
+             style="margin-bottom: 20px; padding: 20px; background-color: #f9f9f9; border-radius: 5px;">
+            <p style="color: #666; font-style: italic; margin: 0;">
+                还没有收藏任何恐龙。点击恐龙名称进入详情页添加收藏吧！
+            </p>
+        </div>
+        
+        <div style="display: flex; flex-wrap: wrap; gap: 10px;">
+            <RouterLink 
+                v-for="dinosaur in displayedDinosaurs" 
+                :key="dinosaur.name"
+                :to="{ name: 'Dinosaur', params: { dinosaur: `${dinosaur.name.toLowerCase()}` } }"
+                class="btn btn-primary"
+                :style="{
+                    display: 'inline-flex',
+                    alignItems: 'center',
+                    gap: '5px'
+                }"
+            >
+                <span v-if="isFavorite(dinosaur)">❤️</span>
+                {{ dinosaur.name }}
+            </RouterLink>
+        </div>
+    </div>
 </template>

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -5,4 +5,6 @@ type Dinosaur = {
 
 type ComponentData = {
     dinosaurDetails: null | Dinosaur;
+    isFavorite: boolean;
+    isLoading: boolean;
 };


### PR DESCRIPTION
新增后端收藏接口，支持获取、添加和取消收藏恐龙；列表页新增只看收藏切换、收藏数量展示和收藏标记，并通过 Deno KV 保存收藏状态。